### PR TITLE
[scala-cli] Update using directives syntax

### DIFF
--- a/src/main/scala/extension.scala
+++ b/src/main/scala/extension.scala
@@ -128,7 +128,7 @@ object extension {
             .mkString(",\n")
         } else if (fileName.endsWith(".scala")) {
           artifacts
-            .map(a => s"""// using lib $groupId::$a:$version""")
+            .map(a => s"""// using lib "$groupId::$a:$version"""")
             .mkString("\n")
         } else
           artifacts


### PR DESCRIPTION
Hi, `scala-cli` recently changed the syntax of using directives a bit. https://github.com/VirtusLab/scala-cli/releases/tag/v0.1.0

The first of the changes is that identifiers like `org.scalameta::munit:1.0.0-M1` are no longer implicitly converted to string literals. i.e. it is required to provide them as strings explicitly - `"org.scalameta::munit:1.0.0-M1"`.

The second change is that the comment syntax is now deprecated and a new syntax with `>` before using directives should be used instead e.g. `// using scala "3.1.1"` -> `//> using scala "3.1.1"`. Though this only results in warnings for now (`0.1.x`), so it is probably better to keep using the previous syntax for now.