### PR TITLE
Add a fallback for accepting atifacts without selecting any

### DIFF
--- a/src/main/scala/extension.scala
+++ b/src/main/scala/extension.scala
@@ -77,7 +77,12 @@ object extension {
       }
 
       inputBox.onDidAccept { _ =>
-        val artifacts = selection
+        val artifacts =
+          if (!selection.isEmpty) {
+            selection
+          } else {
+            inputBox.activeItems.map(_.label)
+          }
         inputBox.dispose()
         versions(projectDetails.groupId, artifacts, projectDetails.versions)
       }


### PR DESCRIPTION
A common case for me is to accidentally press ENTER when having a highlighted artifact, but forget to select the artifact. This fallback makes it so that if no selections were made, the active item will be chosen.

Let me know what you think about this change 😄 

Demo:

https://user-images.githubusercontent.com/39772805/207822436-9e78908e-5445-47e1-98f3-998986f71779.mov


