### PR TITLE
Treat scripts as scala-cli if they have directives

### DIFF
--- a/src/main/scala/extension.scala
+++ b/src/main/scala/extension.scala
@@ -162,7 +162,9 @@ object extension {
     fileName: String,
     fileText: String
   ): Boolean = {
-    fileName.endsWith(".sc") && fileText.contains("//> using")
+    fileName.endsWith(".sc") &&
+    // optional spaces after //> are allowed
+    """//> *using""".r.findFirstIn(fileText).isDefined
   }
 
 }


### PR DESCRIPTION
This should keep the existing functionality in Ammonite scripts (using `$ivy` imports).

Tested manually and worked as intended.