### PR TITLE
Change using directives to use `dep` instead of `lib`

### DIFF
--- a/src/main/scala/extension.scala
+++ b/src/main/scala/extension.scala
@@ -125,7 +125,7 @@ object extension {
             .mkString(",\n")
         } else if (fileName.endsWith(".scala") || isLikelyScalaCliScript(fileName, fileText)) {
           artifacts
-            .map(a => s"""//> using lib "$groupId::$a:$version"""")
+            .map(a => s"""//> using dep "$groupId::$a:$version"""")
             .mkString("\n")
         } else if (fileName.endsWith("bleep.yaml")) {
           artifacts


### PR DESCRIPTION
It looks like scala-cli now gives deprecation warnings when using `lib` instead of `dep` in using directives